### PR TITLE
Expand conf.dockerimages regex

### DIFF
--- a/grc.conf
+++ b/grc.conf
@@ -172,7 +172,7 @@ conf.findmnt
 (^|[/\w\.]+/)docker(-compose)? ps\s?
 conf.dockerps
 
-(^|[/\w\.]+/)docker images\s?
+(^|[/\w\.]+/)docker image(s| ls| list)\s?
 conf.dockerimages
 
 (^|[/\w\.]+/)docker search\s?


### PR DESCRIPTION
Add 'image ls' and 'image list' as alternatives to 'images'

'docker image ls' and 'docker image list' are aliases for 'docker images', colourise them as well.
